### PR TITLE
Fix manifest.json

### DIFF
--- a/GeneralMods/Save_Anywhere_V2/Save_Anywhere_V2/Save_Anywhere_V2.csproj
+++ b/GeneralMods/Save_Anywhere_V2/Save_Anywhere_V2/Save_Anywhere_V2.csproj
@@ -52,6 +52,10 @@
     <Compile Include="Player_Utilities.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="manifest.json" />
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/GeneralMods/Save_Anywhere_V2/Save_Anywhere_V2/manifest.json
+++ b/GeneralMods/Save_Anywhere_V2/Save_Anywhere_V2/manifest.json
@@ -1,14 +1,13 @@
 {
   "Name": "Save Anywhere",
-  "Authour": "Alpha_Omegasis",
+  "Author": "Alpha_Omegasis",
   "Version": {
     "MajorVersion": 2,
-    "MinorVersion": 0,
+    "MinorVersion": 3,
     "PatchVersion": 0,
-    "Build": ""
+    "Build": null
   },
   "Description": "Allows the farmer to save almost anywhere.",
   "UniqueID": "SaveAnywhere",
-  "PerSaveConfigs": false,
   "EntryDll": "Save_Anywhere_V2.dll"
 }


### PR DESCRIPTION
The latest version is Save Anywhere 2.3, but the `manifest.json` still says 2.0. SMAPI 1.9+ blocks Save Anywhere 2.0 due to an incompatibility, which means Save Anywhere 2.3 is also blocked.

This pull request corrects the `manifest.json` to fix that.