### PR TITLE
Tweak AutoSpeed's default speed

### DIFF
--- a/GeneralMods/AutoSpeed/Framework/ModConfig.cs
+++ b/GeneralMods/AutoSpeed/Framework/ModConfig.cs
@@ -4,6 +4,6 @@
     internal class ModConfig
     {
         /// <summary>The added speed.</summary>
-        public int Speed { get; set; } = 1;
+        public int Speed { get; set; } = 5;
     }
 }

--- a/GeneralMods/AutoSpeed/README.md
+++ b/GeneralMods/AutoSpeed/README.md
@@ -24,4 +24,5 @@ set the speed you want (higher values are faster).
 
 1.4:
 * Switched to standard JSON config file.
+* Fixed config defaulting to normal speed.
 * Internal refactoring.


### PR DESCRIPTION
AutoSpeed defaults to the vanilla speed, but players install the mod because they want to walk faster. This pull request changes the initial speed setting in `config.json` to reflect that.