### PR TITLE
Ensure backup saves directory is always made + bundle dependencies

### DIFF
--- a/GeneralMods/AdvancedSaveBackup/AdvancedSaveBackup.csproj
+++ b/GeneralMods/AdvancedSaveBackup/AdvancedSaveBackup.csproj
@@ -6,6 +6,8 @@
     <RootNamespace>Omegasis.SaveBackup</RootNamespace>
 
     <Platforms>AnyCPU;x64</Platforms>
+
+    <BundleExtraAssemblies>ThirdParty</BundleExtraAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GeneralMods/AdvancedSaveBackup/SaveBackup.cs
+++ b/GeneralMods/AdvancedSaveBackup/SaveBackup.cs
@@ -17,10 +17,10 @@ namespace Omegasis.SaveBackup
         ** Fields
         *********/
         /// <summary>The folder path containing the game's app data.</summary>
-        private static readonly string AppDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "StardewValley");
+        private static readonly string AppDataPath = Constants.DataPath;
 
         /// <summary>The folder path containing the game's saves.</summary>
-        private static readonly string SavesPath = Path.Combine(SaveBackup.AppDataPath, "Saves");
+        private static readonly string SavesPath = Constants.SavesPath;
 
         /// <summary>The folder path containing backups of the save before the player starts playing.</summary>
         private static readonly string PrePlayBackupsPath = Path.Combine(SaveBackup.AppDataPath, "Backed_Up_Saves", "Pre_Play_Saves");
@@ -92,12 +92,12 @@ namespace Omegasis.SaveBackup
         {
             //Ensure the backup directory is created and exists.
             //CreateDirectory will do nothing if it already exists.
-            Directory.CreateDirectory(folderPath);
+            DirectoryInfo backupDir = Directory.CreateDirectory(folderPath);
             if (this.Config.UseZipCompression == false)
             {
 
                 DirectoryCopy(Constants.TargetPlatform != GamePlatform.Android ? SaveBackup.SavesPath : SaveBackup.AndroidCurrentSavePath, Path.Combine(folderPath, $"backup-{DateTime.Now:yyyyMMdd'-'HHmmss}"), true);
-                new DirectoryInfo(folderPath)
+                backupDir
                 .EnumerateDirectories()
                 .OrderByDescending(f => f.CreationTime)
                 .Skip(this.Config.SaveCount)
@@ -106,12 +106,14 @@ namespace Omegasis.SaveBackup
             }
             else
             {
-                FastZip fastZip = new FastZip();
-                fastZip.UseZip64 = UseZip64.Off;
+                FastZip fastZip = new FastZip
+                {
+                    UseZip64 = UseZip64.Off
+                };
                 bool recurse = true;  // Include all files by recursing through the directory structure
                 string filter = null; // Dont filter any files at all
                 fastZip.CreateZip(Path.Combine(folderPath, $"backup-{DateTime.Now:yyyyMMdd'-'HHmmss}.zip"), Constants.TargetPlatform != GamePlatform.Android ? SaveBackup.SavesPath : SaveBackup.AndroidCurrentSavePath, recurse, filter);
-                new DirectoryInfo(folderPath)
+                backupDir
                 .EnumerateFiles()
                 .OrderByDescending(f => f.CreationTime)
                 .Skip(this.Config.SaveCount)

--- a/GeneralMods/AdvancedSaveBackup/SaveBackup.cs
+++ b/GeneralMods/AdvancedSaveBackup/SaveBackup.cs
@@ -82,10 +82,6 @@ namespace Omegasis.SaveBackup
             }
             else
             {
-                if (!Directory.Exists(SaveBackup.AndroidNightlyBackupsPath))
-                {
-                    Directory.CreateDirectory(SaveBackup.AndroidNightlyBackupsPath);
-                }
                 this.BackupSaves(SaveBackup.AndroidNightlyBackupsPath);
             }
         }
@@ -94,6 +90,9 @@ namespace Omegasis.SaveBackup
         /// <param name="folderPath">The folder path in which to generate saves.</param>
         private void BackupSaves(string folderPath)
         {
+            //Ensure the backup directory is created and exists.
+            //CreateDirectory will do nothing if it already exists.
+            Directory.CreateDirectory(folderPath);
             if (this.Config.UseZipCompression == false)
             {
 


### PR DESCRIPTION
Currently, the mod doesn't ensure that the backups directory is made, which will sometimes cause errors. (One's reported in the bugs tab here right now: https://www.nexusmods.com/stardewvalley/mods/435?tab=bugs). These changes simply ensure that the the backups directory is always made for every platform.

Additionally, for me at least, without bundling dependencies I don't have access to the zip library, so it might be worth enabling that option.