### PR TITLE
Fix deprecated code in Billboard Anywhere

### DIFF
--- a/GeneralMods/BillboardAnywhere/BillboardAnywhere.cs
+++ b/GeneralMods/BillboardAnywhere/BillboardAnywhere.cs
@@ -58,8 +58,8 @@ namespace Omegasis.BillboardAnywhere
             helper.Events.Input.ButtonPressed += this.OnButtonPressed;
             helper.Events.Display.RenderedActiveMenu += this.RenderBillboardMenuButton;
 
-            this.calendarTexture = helper.Content.Load<Texture2D>(Path.Combine("Assets", "Billboard.png"));
-            this.questTexture = helper.Content.Load<Texture2D>(Path.Combine("Assets", "Quest.png"));
+            this.calendarTexture = helper.GameContent.Load<Texture2D>(Path.Combine("Assets", "Billboard.png"));
+            this.questTexture = helper.GameContent.Load<Texture2D>(Path.Combine("Assets", "Quest.png"));
             this.billboardButton = new ClickableTextureComponent(new Rectangle((int)this.Config.CalendarOffsetFromMenu.X, (int)this.Config.CalendarOffsetFromMenu.Y, this.calendarTexture.Width, this.calendarTexture.Height), this.calendarTexture, new Rectangle(0, 0, this.calendarTexture.Width, this.calendarTexture.Height), 1f, false);
             this.questButton = new ClickableTextureComponent(new Rectangle((int)this.Config.QuestOffsetFromMenu.X, (int)this.Config.QuestOffsetFromMenu.Y, this.questTexture.Width, this.questTexture.Height), this.questTexture, new Rectangle(0, 0, this.questTexture.Width, this.questTexture.Height), 1f, false);
         }

--- a/GeneralMods/BillboardAnywhere/BillboardAnywhere.cs
+++ b/GeneralMods/BillboardAnywhere/BillboardAnywhere.cs
@@ -58,8 +58,8 @@ namespace Omegasis.BillboardAnywhere
             helper.Events.Input.ButtonPressed += this.OnButtonPressed;
             helper.Events.Display.RenderedActiveMenu += this.RenderBillboardMenuButton;
 
-            this.calendarTexture = helper.GameContent.Load<Texture2D>(Path.Combine("Assets", "Billboard.png"));
-            this.questTexture = helper.GameContent.Load<Texture2D>(Path.Combine("Assets", "Quest.png"));
+            this.calendarTexture = helper.ModContent.Load<Texture2D>(Path.Combine("Assets", "Billboard.png"));
+            this.questTexture = helper.ModContent.Load<Texture2D>(Path.Combine("Assets", "Quest.png"));
             this.billboardButton = new ClickableTextureComponent(new Rectangle((int)this.Config.CalendarOffsetFromMenu.X, (int)this.Config.CalendarOffsetFromMenu.Y, this.calendarTexture.Width, this.calendarTexture.Height), this.calendarTexture, new Rectangle(0, 0, this.calendarTexture.Width, this.calendarTexture.Height), 1f, false);
             this.questButton = new ClickableTextureComponent(new Rectangle((int)this.Config.QuestOffsetFromMenu.X, (int)this.Config.QuestOffsetFromMenu.Y, this.questTexture.Width, this.questTexture.Height), this.questTexture, new Rectangle(0, 0, this.questTexture.Width, this.questTexture.Height), 1f, false);
         }

--- a/GeneralMods/BillboardAnywhere/manifest.json
+++ b/GeneralMods/BillboardAnywhere/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Billboard Anywhere",
   "Author": "Alpha_Omegasis",
-  "Version": "1.11.0",
+  "Version": "1.12.0",
   "Description": "Lets you view the billboard from anywhere.",
   "UniqueID": "Omegasis.BillboardAnywhere",
   "EntryDll": "BillboardAnywhere.dll",


### PR DESCRIPTION
Running Billboard Anywhere (version 1.12.0 from Nexus) on SMAPI 3.16.0+ produces this warning:

```
[SMAPI] Billboard Anywhere uses deprecated code (IModHelper.Content is deprecated since SMAPI 3.14.0).
   at Omegasis.BillboardAnywhere.BillboardAnywhere.Entry(IModHelper helper)
   at StardewModdingAPI.Framework.SCore.LoadMods(IModMetadata[] mods, JsonHelper jsonHelper, ContentCoordinator contentCore, ModDatabase modDatabase)
```

This is a PR to fix the deprecated code and update the manifest to match the version on SMAPI/Nexus. 
