### PR TITLE
Correctly handle base bonuses; other fixes.

### DIFF
--- a/GeneralMods/BuildEndurance/BuildEndurance.cs
+++ b/GeneralMods/BuildEndurance/BuildEndurance.cs
@@ -116,7 +116,10 @@ namespace Omegasis.BuildEndurance
             this.WasEating = false;
 
             // load player data
-            this.PlayerData = this.Helper.Data.ReadJsonFile<PlayerData>(this.RelativeDataPath) ?? new PlayerData();
+            this.PlayerData = this.Helper.Data.ReadJsonFile<PlayerData>(this.RelativeDataPath)
+                ?? new PlayerData {
+                    ExpToNextLevel = this.Config.ExpToNextLevel
+                };
             if (this.PlayerData.OriginalMaxStamina == 0)
                 this.PlayerData.OriginalMaxStamina = Game1.player.MaxStamina;
 
@@ -125,10 +128,9 @@ namespace Omegasis.BuildEndurance
             {
                 Game1.player.MaxStamina = this.PlayerData.OriginalMaxStamina;
                 this.PlayerData.ExpToNextLevel = this.Config.ExpToNextLevel;
-                this.PlayerData.CurrentExp = this.Config.CurrentExp;
+                this.PlayerData.CurrentExp = 0;
                 this.PlayerData.CurrentLevelStaminaBonus = 0;
                 this.PlayerData.OriginalMaxStamina = Game1.player.MaxStamina;
-                this.PlayerData.BaseStaminaBonus = 0;
                 this.PlayerData.CurrentLevel = 0;
                 this.PlayerData.ClearModEffects = false;
             }
@@ -137,8 +139,10 @@ namespace Omegasis.BuildEndurance
             else
             {
                 Game1.player.MaxStamina = this.PlayerData.NightlyStamina <= 0
-                    ? this.PlayerData.BaseStaminaBonus + this.PlayerData.CurrentLevelStaminaBonus + this.PlayerData.OriginalMaxStamina
+                    ? this.Config.BaseStaminaBonus + this.PlayerData.CurrentLevelStaminaBonus + this.PlayerData.OriginalMaxStamina
                     : this.PlayerData.NightlyStamina;
+                if (Game1.player.Stamina > Game1.player.MaxStamina)
+                    Game1.player.Stamina = Game1.player.MaxStamina;
             }
         }
 

--- a/GeneralMods/BuildEndurance/Framework/ModConfig.cs
+++ b/GeneralMods/BuildEndurance/Framework/ModConfig.cs
@@ -6,17 +6,8 @@ namespace Omegasis.BuildEndurance.Framework
         /// <summary>The XP points needed to reach the next endurance level.</summary>
         public double ExpToNextLevel { get; set; } = 20;
 
-        /// <summary>The player's current endurance XP points.</summary>
-        public double CurrentExp { get; set; }
-
-        /// <summary>The player's current endurance level.</summary>
-        public int CurrentLevel { get; set; }
-
         /// <summary>The initial stamina bonus to apply regardless of the player's endurance level.</summary>
         public int BaseStaminaBonus { get; set; }
-
-        /// <summary>The stamina points to add to the player's base stamina due to their current endurance level.</summary>
-        public int CurrentLevelStaminaBonus { get; set; }
 
         /// <summary>The multiplier for the experience points to need to reach an endurance level relative to the previous one.</summary>
         public double ExpCurve { get; set; } = 1.15;

--- a/GeneralMods/BuildEndurance/Framework/PlayerData.cs
+++ b/GeneralMods/BuildEndurance/Framework/PlayerData.cs
@@ -12,9 +12,6 @@ namespace Omegasis.BuildEndurance.Framework
         /// <summary>The XP points needed to reach the next endurance level.</summary>
         public double ExpToNextLevel { get; set; } = 20;
 
-        /// <summary>The initial stamina bonus to apply regardless of the player's endurance level, from the config file.</summary>
-        public int BaseStaminaBonus { get; set; }
-
         /// <summary>The stamina points to add to the player's base stamina due to their current endurance level.</summary>
         public int CurrentLevelStaminaBonus { get; set; }
 

--- a/GeneralMods/BuildEndurance/manifest.json
+++ b/GeneralMods/BuildEndurance/manifest.json
@@ -1,8 +1,8 @@
 {
   "Name": "Build Endurance",
   "Author": "Alpha_Omegasis",
-  "Version": "1.9.0",
-  "Description": "Increase your health as you play.",
+  "Version": "1.9.1",
+  "Description": "Increase your stamina as you play.",
   "UniqueID": "Omegasis.BuildEndurance",
   "EntryDll": "BuildEndurance.dll",
   "MinimumApiVersion": "3.0.0",

--- a/GeneralMods/BuildHealth/Framework/ModConfig.cs
+++ b/GeneralMods/BuildHealth/Framework/ModConfig.cs
@@ -6,17 +6,8 @@ namespace Omegasis.BuildHealth.Framework
         /// <summary>The XP points needed to reach the next level.</summary>
         public double ExpToNextLevel { get; set; } = 20;
 
-        /// <summary>The player's current XP points.</summary>
-        public double CurrentExp { get; set; }
-
-        /// <summary>The player's current level.</summary>
-        public int CurrentLevel { get; set; }
-
         /// <summary>The initial health bonus to apply regardless of the player's level, from the config file.</summary>
         public int BaseHealthBonus { get; set; }
-
-        /// <summary>The health points to add to the player's base health due to their current level.</summary>
-        public int CurrentLevelHealthBonus { get; set; }
 
         /// <summary>The multiplier for the experience points to need to reach an endurance level relative to the previous one.</summary>
         public double ExpCurve { get; set; } = 1.15;

--- a/GeneralMods/BuildHealth/Framework/PlayerData.cs
+++ b/GeneralMods/BuildHealth/Framework/PlayerData.cs
@@ -12,9 +12,6 @@ namespace Omegasis.BuildHealth.Framework
         /// <summary>The XP points needed to reach the next endurance level.</summary>
         public double ExpToNextLevel { get; set; } = 20;
 
-        /// <summary>The initial health bonus to apply regardless of the player's endurance level, from the config file.</summary>
-        public int BaseHealthBonus { get; set; }
-
         /// <summary>The health points to add to the player's base health due to their current endurance level.</summary>
         public int CurrentLevelHealthBonus { get; set; }
 

--- a/GeneralMods/BuildHealth/manifest.json
+++ b/GeneralMods/BuildHealth/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Build Health",
   "Author": "Alpha_Omegasis",
-  "Version": "1.9.0",
+  "Version": "1.9.1",
   "Description": "Increase your health as you play.",
   "UniqueID": "Omegasis.BuildHealth",
   "EntryDll": "BuildHealth.dll",


### PR DESCRIPTION
Fixes #93.

Applies to BuildEndurance and BuildHealth:
- ModConfig no longer includes data that is player-specific.
- PlayerData no longer includes data that is configuration-specific.
- PlayerData is properly initialized for new players.
- Maximum health/stamina factors in configured base bonus.
- Current health/stamina is clamped by maximum as needed.

Applies to BuildEndurance:
- Manifest description corrected.

Applies to BuildHealth:
- Player-specific data is saved at the end of the day.