### PR TITLE
Add config to backup saves after save, not before

### DIFF
--- a/GeneralMods/AdvancedSaveBackup/Framework/ModConfig.cs
+++ b/GeneralMods/AdvancedSaveBackup/Framework/ModConfig.cs
@@ -14,5 +14,8 @@ namespace Omegasis.SaveBackup.Framework
         public string AlternateNightlySaveBackupPath { get; set; } = "";
 
         public string AlternatePreplaySaveBackupPath { get; set; } = "";
+
+        /// <summary>Back up the save after saving instead of before saving.</summary>
+        public bool BackupAfterSave { get; set; } = false;
     }
 }

--- a/GeneralMods/AdvancedSaveBackup/SaveBackup.cs
+++ b/GeneralMods/AdvancedSaveBackup/SaveBackup.cs
@@ -70,6 +70,8 @@ namespace Omegasis.SaveBackup
             }
 
             helper.Events.GameLoop.Saving += this.OnSaving;
+            helper.Events.GameLoop.Saved += this.OnSaved;
+            helper.Events.GameLoop.SaveCreated += this.OnSaveCreated;
         }
 
         /// <summary>
@@ -117,6 +119,27 @@ namespace Omegasis.SaveBackup
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event arguments.</param>
         private void OnSaving(object sender, SavingEventArgs e)
+        {
+            if (!this.Config.BackupAfterSave) this.DoBackup();
+        }
+
+        /// <summary>Raised after the game finishes writing data to the save file (except the initial save creation).</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void OnSaved(object sender, SavedEventArgs e)
+        {
+            if (this.Config.BackupAfterSave) this.DoBackup();
+        }
+
+        /// <summary>Raised after the game finishes creating the save file.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void OnSaveCreated(object sender, SaveCreatedEventArgs e)
+        {
+            if (this.Config.BackupAfterSave) this.DoBackup();
+        }
+
+        private void DoBackup()
         {
             if (string.IsNullOrEmpty(this.Config.AlternateNightlySaveBackupPath) == false)
             {

--- a/GeneralMods/AdvancedSaveBackup/manifest.json
+++ b/GeneralMods/AdvancedSaveBackup/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Advanced Save Backup",
   "Author": "Alpha_Omegasis",
-  "Version": "1.12.1",
+  "Version": "1.13.0",
   "Description": "Backs up your save files when loading SMAPI and every in game night when saving.",
   "UniqueID": "Omegasis.AdvancedSaveBackup",
   "EntryDll": "AdvancedSaveBackup.dll",


### PR DESCRIPTION
Adds a config option "BackupAfterSave" that causes save files to be backed up after saving instead of before saving. This allows the backup saves directory to contain a copy of all save files, not just the old ones. This also removes the extremely small risk of causing a crash before saving and thus losing progress. Defaults to backing up the save before saving, which is the original behaviour.

Bumps version to 1.13.0.