### PR TITLE
[Billboard Anywhere] Implement support for Better Game Menu.

### DIFF
--- a/GeneralMods/BillboardAnywhere/BillboardAnywhere.cs
+++ b/GeneralMods/BillboardAnywhere/BillboardAnywhere.cs
@@ -1,12 +1,18 @@
 using System;
 using System.IO;
-using System.Linq;
+
 using GenericModConfigMenu;
+
+using Leclair.Stardew.BetterGameMenu;
+
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+
 using Omegasis.BillboardAnywhere.Framework;
+
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
+
 using StardewValley;
 using StardewValley.Menus;
 
@@ -20,6 +26,11 @@ namespace Omegasis.BillboardAnywhere
         *********/
         /// <summary>The mod configuration.</summary>
         private ModConfig Config;
+
+        /// <summary>
+        /// The API for Better Game Menu.
+        /// </summary>
+        private IBetterGameMenuApi BetterGameMenuApi;
 
         /// <summary>
         /// The texture for the calendar button.
@@ -84,6 +95,9 @@ namespace Omegasis.BillboardAnywhere
 
         private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
         {
+            // get Better Game Menu's API (if it's installed) and store it for later use
+            this.BetterGameMenuApi = this.Helper.ModRegistry.GetApi<IBetterGameMenuApi>("leclair.bettergamemenu");
+
             // get Generic Mod Config Menu's API (if it's installed)
             var configMenu = this.Helper.ModRegistry.GetApi<IGenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
             if (configMenu is null)
@@ -236,7 +250,7 @@ namespace Omegasis.BillboardAnywhere
             {
                 Game1.activeClickableMenu = new SpecialOrdersBoard("Qi");
             }
-            
+
 
             // check if billboard icon was clicked
             else if (e.Button == SButton.MouseLeft && this.isInventoryPage())
@@ -251,11 +265,11 @@ namespace Omegasis.BillboardAnywhere
 
                 else if (this.Config.EnableSpecialOrdersButton && this.specialOrderButton.containsPoint(mouse.X, mouse.Y) && Game1.player.eventsSeen.Contains("15389722"))
                     Game1.activeClickableMenu = new SpecialOrdersBoard();
-                
+
                 else if (this.Config.EnableQiBoardButton && this.qiBoardButton.containsPoint(mouse.X, mouse.Y) && Game1.player.eventsSeen.Contains("10040609"))
                     Game1.activeClickableMenu = new SpecialOrdersBoard("Qi");
             }
-            
+
         }
 
         /// <summary>
@@ -277,8 +291,7 @@ namespace Omegasis.BillboardAnywhere
                 if (this.Config.EnableSpecialOrdersButton && Game1.player.eventsSeen.Contains("15389722")) this.specialOrderButton.draw(Game1.spriteBatch);
                 if (this.Config.EnableQiBoardButton && Game1.player.eventsSeen.Contains("10040609")) this.qiBoardButton.draw(Game1.spriteBatch);
 
-                GameMenu activeMenu = (Game1.activeClickableMenu as GameMenu);
-                activeMenu.drawMouse(Game1.spriteBatch);
+                Game1.activeClickableMenu.drawMouse(e.SpriteBatch);
 
                 if (this.calendarButton.containsPoint(Game1.getMousePosition().X, Game1.getMousePosition().Y))
                 {
@@ -329,9 +342,9 @@ namespace Omegasis.BillboardAnywhere
         /// </summary>
         private bool isInventoryPage()
         {
-            return
-                Game1.activeClickableMenu is GameMenu gameMenu
-                && gameMenu.GetCurrentPage() is InventoryPage;
+            if (Game1.activeClickableMenu is GameMenu gameMenu)
+                return gameMenu.GetCurrentPage() is InventoryPage;
+            return this.BetterGameMenuApi?.ActivePage is InventoryPage;
         }
 
 

--- a/GeneralMods/BillboardAnywhere/Framework/IBetterGameMenuApi.cs
+++ b/GeneralMods/BillboardAnywhere/Framework/IBetterGameMenuApi.cs
@@ -1,0 +1,24 @@
+#nullable enable
+
+using StardewValley.Menus;
+
+namespace Leclair.Stardew.BetterGameMenu;
+
+
+public interface IBetterGameMenuApi
+{
+
+    #region Menu Class Access
+
+    /// <summary>
+    /// The current page of the active screen's current Better Game Menu,
+    /// if one is open, else <c>null</c>. This exists as a quicker alternative
+    /// to <c>ActiveMenu?.CurrentPage</c> with the additional benefit that
+    /// you can prune <c>IBetterGameMenu</c> from your copy of the API
+    /// file if you're not using anything else from it.
+    /// </summary>
+    IClickableMenu? ActivePage { get; }
+
+    #endregion
+
+}


### PR DESCRIPTION
Hello!

[Better Game Menu](https://www.nexusmods.com/stardewvalley/mods/32032) is a fairly new mod I've developed that replaces `GameMenu` with the goal that it:

1. Is considerably more efficient by virtue of only creating page instances when the pages are actually accessed.
2. Has a robust API to let other mods work with the game menu, making it easy to register new tabs, override existing tabs, and respond to events involving the menu.

I realize this has the potential to break a lot of things, so I've submitted PRs to various mods that interact with GameMenu to implement support for BetterGameMenu. This is such a PR.

---

I've updated your `isInventoryPage()` method to use Better Game Menu's API to check the current page of the current menu. Additionally, in your rendering method I removed your unnecessary cast to GameMenu (and the unnecessary local variable that went with it) when drawing the mouse.

I hope this is helpful. Please contact me if you have any questions!